### PR TITLE
[DDA-101] validate token

### DIFF
--- a/src/main/java/com/ddalggak/finalproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/ddalggak/finalproject/domain/user/controller/UserController.java
@@ -2,7 +2,6 @@ package com.ddalggak.finalproject.domain.user.controller;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -152,7 +151,8 @@ public class UserController {
 	@GetMapping("/auth/validToken")
 	public ResponseEntity<?> validToken(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		Token token = tokenRepository.findByEmail(userDetails.getEmail());
-		if(token == null) {throw new UserException(ErrorCode.INVALID_REQUEST);
+		if (token == null) {
+			throw new UserException(ErrorCode.INVALID_REQUEST);
 		}
 		return SuccessResponseDto.toResponseEntity(SuccessCode.SUCCESS_UPLOAD);
 	}

--- a/src/main/java/com/ddalggak/finalproject/domain/user/controller/UserController.java
+++ b/src/main/java/com/ddalggak/finalproject/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.ddalggak.finalproject.domain.user.controller;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -24,6 +25,7 @@ import com.ddalggak.finalproject.domain.user.dto.EmailRequestDto;
 import com.ddalggak.finalproject.domain.user.dto.NicknameRequestDto;
 import com.ddalggak.finalproject.domain.user.dto.UserRequestDto;
 import com.ddalggak.finalproject.domain.user.entity.User;
+import com.ddalggak.finalproject.domain.user.exception.UserException;
 import com.ddalggak.finalproject.domain.user.repository.UserRepository;
 import com.ddalggak.finalproject.domain.user.service.UserService;
 import com.ddalggak.finalproject.global.dto.SuccessCode;
@@ -31,6 +33,8 @@ import com.ddalggak.finalproject.global.dto.SuccessResponseDto;
 import com.ddalggak.finalproject.global.error.ErrorCode;
 import com.ddalggak.finalproject.global.error.ErrorResponse;
 import com.ddalggak.finalproject.global.jwt.JwtUtil;
+import com.ddalggak.finalproject.global.jwt.token.entity.Token;
+import com.ddalggak.finalproject.global.jwt.token.repository.TokenRepository;
 import com.ddalggak.finalproject.global.mail.MailService;
 import com.ddalggak.finalproject.global.mail.randomCode.RandomCodeDto;
 import com.ddalggak.finalproject.global.mail.randomCode.RandomCodeService;
@@ -48,6 +52,7 @@ public class UserController {
 	private final UserRepository userRepository;
 	private final MailService mailService;
 	private final RandomCodeService randomCodeService;
+	private final TokenRepository tokenRepository;
 
 	@PostMapping("/auth/email")
 	public ResponseEntity<?> emailAuthentication(@Valid @RequestBody EmailRequestDto emailRequestDto,
@@ -142,6 +147,14 @@ public class UserController {
 	@GetMapping("/user")
 	public ResponseEntity<?> getMyPage(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return userService.getMyPage(userDetails.getEmail());
+	}
+
+	@GetMapping("/auth/validToken")
+	public ResponseEntity<?> validToken(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		Token token = tokenRepository.findByEmail(userDetails.getEmail());
+		if(token == null) {throw new UserException(ErrorCode.INVALID_REQUEST);
+		}
+		return SuccessResponseDto.toResponseEntity(SuccessCode.SUCCESS_UPLOAD);
 	}
 
 }

--- a/src/main/java/com/ddalggak/finalproject/global/jwt/token/repository/TokenRepository.java
+++ b/src/main/java/com/ddalggak/finalproject/global/jwt/token/repository/TokenRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.ddalggak.finalproject.global.jwt.token.entity.Token;
 
 public interface TokenRepository extends JpaRepository<Token, Long> {
+	Token findByEmail(String email);
 }


### PR DESCRIPTION
사용자가 URL에 페이지 정보를 입력해서 연결할 경우
react에서 가지고 있는 정보로 page를 연결해줘서 백엔드로 get 요청이 가지 않는다.(= 권한 없이 접근이 가능)
이 때문에 token 유효성 검사를 따로 만들어서 그 과정에 끼워넣어 줘서 권한 확인을 한다.